### PR TITLE
facets: filtered query usage

### DIFF
--- a/invenio_search/config.py
+++ b/invenio_search/config.py
@@ -196,3 +196,10 @@ SEARCH_ELASTIC_COLLECTION_INDEX_MAPPING = {
 # SEARCH_ELASTIC_DEFAULT_INDEX -- elasticsearch default index used when
 # indexing and searching for records.
 SEARCH_ELASTIC_DEFAULT_INDEX = 'records'
+
+
+# SEARCH_ELASTIC_AGGREGATIONS -- elasticsearch aggregations used when
+# searching for records. Keys are collection names (in lowercase) and
+# values are the aggregations.
+# E.g {'poetry': {'author': {'terms':{'field': 'author.name'}}}}
+SEARCH_ELASTIC_AGGREGATIONS = {}

--- a/invenio_search/static/js/search/init.js
+++ b/invenio_search/static/js/search/init.js
@@ -20,7 +20,6 @@
 require(
     [
         "js/search/facets_menu",
-        "js/search/facet",
         "js/search/search",
         "js/search/facets_filter",
         "js/search/form",

--- a/invenio_search/static/js/search/search.js
+++ b/invenio_search/static/js/search/search.js
@@ -22,8 +22,9 @@ define([
         'jquery',
         'flight/lib/component',
         'js/search/facets_filter',
+        'js/search/search_results',
 ],
-function($, defineComponent, FacetsFilter) {
+function($, defineComponent, FacetsFilter, SearchResults) {
 
   /**
    * Serialize the given filters as a query.
@@ -115,9 +116,10 @@ function($, defineComponent, FacetsFilter) {
         queryString = setQueryStringParam(queryString,
                                           this.attr.userQueryParam,
                                           userQuery);
+        var filtered_query = queryString.replace(/[^=&]+=(&|$)/g,"").replace(/&$/,"");
         // rebuild the URL
         var path = window.location.origin + window.location.pathname +
-          queryString + window.location.hash;
+          filtered_query + window.location.hash;
 
         window.history.pushState({
           path: path,
@@ -258,8 +260,9 @@ function($, defineComponent, FacetsFilter) {
         data: data,
         context: $(that.attr.searchResultsSelector)
       }).done(function(response) {
-
         $(this).html(response);
+        SearchResults.teardownAll();
+        SearchResults.attachTo(document);
       });
     }
   };


### PR DESCRIPTION
- Changes aggregation behaviour to use filtered query instead
  of post_filter in order to have document count updated when
  filtering.
- Adds config variable SEARCH_ELASTIC_AGGREGATIONS that allows
  the customisation of the aggregations.

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
