### PR TITLE
walkers: author keyword fix

### DIFF
--- a/invenio_search/walkers/elasticsearch.py
+++ b/invenio_search/walkers/elasticsearch.py
@@ -120,8 +120,7 @@ class ElasticSearchDSL(object):
     @visitor(DoubleQuotedValue)
     def visit(self, node):
         def _f(keyword):
-            exactauthor = self.keyword_dict.get('author').get('e')
-            if keyword == exactauthor:
+            if keyword == ['author']:
                 from inspirehep.modules.authors.utils import author_tokenize
                 name_variations = author_tokenize(node.value)
                 return {"bool": {"must": [{"terms": {"authors.name_variations": name_variations}}], "should": [


### PR DESCRIPTION
- Only applies the name variants when looking in the author
  keyword. This allows for querying the exactauthor.raw field
  directly.

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
