### PR TITLE
search: reload fix for Safari

### DIFF
--- a/invenio_search/version.py
+++ b/invenio_search/version.py
@@ -28,4 +28,4 @@ This file is imported by ``invenio_search.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.1.6.dev20151218"
+__version__ = "0.1.6.dev20160108"


### PR DESCRIPTION
- Fixes infinite reloading on Safari due to the browser calling
  PopState on first page load.

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
