### PR TITLE
elasticsearch_DSL: enables doi/eprint search

### DIFF
--- a/invenio_search/walkers/elasticsearch_no_keywords.py
+++ b/invenio_search/walkers/elasticsearch_no_keywords.py
@@ -51,7 +51,7 @@ class ElasticSearchNoKeywordsDSL(object):
         return {
             "multi_match": {
                 "message": {
-                    "query": self.values,
+                    "query": str.strip(str(self.values)),
                     "operator": "or",
                     "zero_terms_query": "all",
                     "fields": [
@@ -78,7 +78,7 @@ class ElasticSearchNoKeywordsDSL(object):
         return {
             "multi_match": {
                 "message": {
-                    "query": self.values,
+                    "query": str.strip(str(self.values)),
                     "operator": "or",
                     "zero_terms_query": "all",
                     "fields": [


### PR DESCRIPTION
- Fixes the problem with eprint and doi searches.
- Addresses inspirehep/inspire-next#716 .

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
