### PR TITLE
elasticsearch_DSL: bug fixes

### DIFF
--- a/invenio_search/api.py
+++ b/invenio_search/api.py
@@ -71,7 +71,23 @@ class Query(object):
                                  collection=collection)
         try:
             walker = ElasticSearchNoKeywordsDSL()
-            query = query.accept(walker)
+            query.accept(walker)
+            query = {
+                "multi_match": {
+                    "message": {
+                        "query": self._query,
+                        "operator": "or",
+                        "zero_terms_query": "all",
+                        "fields": [
+                            "title^3",
+                            "title.raw^10",
+                            "abstract^2",
+                            "abstract.raw^4",
+                            "author^10",
+                            "author.raw^15",
+                            "reportnumber^10",
+                            "eprint^10",
+                            "doi^10"]}}}
         except QueryHasKeywords:
             for walker in search_walkers():
                 query = query.accept(walker)

--- a/invenio_search/version.py
+++ b/invenio_search/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -28,4 +28,4 @@ This file is imported by ``invenio_search.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.1.6.dev20160118"
+__version__ = "0.1.6.dev20160121"

--- a/invenio_search/walkers/elasticsearch_no_keywords.py
+++ b/invenio_search/walkers/elasticsearch_no_keywords.py
@@ -39,31 +39,13 @@ class ElasticSearchNoKeywordsDSL(object):
 
     visitor = make_visitor()
 
-    def __init__(self):
-        self.values = ""
-
     @visitor(KeywordOp)
     def visit(self, node, left, right):
         raise QueryHasKeywords()
 
     @visitor(AndOp)
     def visit(self, node, left, right):
-        return {
-            "multi_match": {
-                "message": {
-                    "query": self.values,
-                    "operator": "or",
-                    "zero_terms_query": "all",
-                    "fields": [
-                        "title^3",
-                        "title.raw^10",
-                        "abstract^2",
-                        "abstract.raw^4",
-                        "author^10",
-                        "author.raw^15",
-                        "reportnumber^10",
-                        "eprint^10",
-                        "doi^10"]}}}
+        return
 
     @visitor(OrOp)
     def visit(self, node, left, right):
@@ -75,22 +57,7 @@ class ElasticSearchNoKeywordsDSL(object):
 
     @visitor(ValueQuery)
     def visit(self, node, op):
-        return {
-            "multi_match": {
-                "message": {
-                    "query": self.values,
-                    "operator": "or",
-                    "zero_terms_query": "all",
-                    "fields": [
-                        "title^3",
-                        "title.raw^10",
-                        "abstract^2",
-                        "abstract.raw^4",
-                        "author^10",
-                        "author.raw^15",
-                        "reportnumber^10",
-                        "eprint^10",
-                        "doi^10"]}}}
+        return
 
     @visitor(Keyword)
     def visit(self, node):
@@ -98,15 +65,15 @@ class ElasticSearchNoKeywordsDSL(object):
 
     @visitor(Value)
     def visit(self, node):
-        self.values += node.value + ' '
+        pass
 
     @visitor(SingleQuotedValue)
     def visit(self, node):
-        self.values += node.value + ' '
+        pass
 
     @visitor(DoubleQuotedValue)
     def visit(self, node):
-        self.values += node.value + ' '
+        pass
 
     @visitor(RegexValue)
     def visit(self, node):
@@ -118,9 +85,7 @@ class ElasticSearchNoKeywordsDSL(object):
 
     @visitor(EmptyQuery)
     def visit(self, node):
-        return {
-            "match_all": {}
-        }
+        return
 
     @visitor(GreaterOp)
     def visit(self, node, value_fn):


### PR DESCRIPTION
- Now uses api to get the query instead of reconstructing it.
- Fixes the problem with eprint and doi searches.
- Addresses inspirehep/inspire-next#716 .

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
