### PR TITLE
api: malformed queries

### DIFF
--- a/invenio_search/api.py
+++ b/invenio_search/api.py
@@ -54,7 +54,11 @@ class Query(object):
     @cached_property
     def query(self):
         """Parse query string using given grammar."""
-        tree = pypeg2.parse(self._query, parser(), whitespace="")
+        try:
+            tree = pypeg2.parse(self._query, parser(), whitespace="")
+        except SyntaxError:
+            from invenio_query_parser.ast import MalformedQuery
+            return MalformedQuery("")
         for walker in query_walkers():
             tree = tree.accept(walker)
         return tree

--- a/invenio_search/version.py
+++ b/invenio_search/version.py
@@ -28,4 +28,4 @@ This file is imported by ``invenio_search.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.1.6.dev20160122"
+__version__ = "0.1.6.dev20160128"

--- a/invenio_search/walkers/elasticsearch_no_keywords.py
+++ b/invenio_search/walkers/elasticsearch_no_keywords.py
@@ -23,8 +23,9 @@ from invenio_query_parser.ast import (
     AndOp, DoubleQuotedValue, EmptyQuery,
     GreaterEqualOp, GreaterOp, Keyword,
     KeywordOp, LowerEqualOp, LowerOp,
-    NotOp, OrOp, RangeOp, RegexValue,
+    MalformedQuery, NotOp, OrOp, RangeOp, RegexValue,
     SingleQuotedValue, Value, ValueQuery
+
 )
 from invenio_query_parser.visitor import make_visitor
 
@@ -42,6 +43,11 @@ class ElasticSearchNoKeywordsDSL(object):
     @visitor(KeywordOp)
     def visit(self, node, left, right):
         raise QueryHasKeywords()
+
+    @visitor(MalformedQuery)
+    def visit(self, op):
+        # FIXME: Should send signal to display a message to the user.
+        return
 
     @visitor(AndOp)
     def visit(self, node, left, right):


### PR DESCRIPTION
- Interprets malformed queries as google-like searches instead
  of throwing exceptions.
- Should be merged with inspirehep/invenio-query-parser#9 .
- Closes inspirehep/inspire-next#763 .

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
