### PR TITLE
api: Query.recids ES 2.0 compatibility

### DIFF
--- a/invenio_search/api.py
+++ b/invenio_search/api.py
@@ -25,6 +25,8 @@ from flask import current_app
 
 from flask_login import current_user
 
+from elasticsearch.helpers import scan
+
 from invenio_base.globals import cfg
 from invenio_base.helpers import unicodifier
 
@@ -130,19 +132,18 @@ class Results(object):
 
     @property
     def recids(self):
-        # FIXME add warnings
         from intbitset import intbitset
         from invenio_ext.es import es
-        results = es.search(
+        results = scan(
+            es,
+            query={
+                'fields': [],
+                'query': self.body.get("query")
+            },
             index=self.index,
             doc_type=self.doc_type,
-            body={
-                'size': 9999999,
-                'fields': ['control_number'],
-                'query': self.body.get("query")
-            }
         )
-        return intbitset([int(r['_id']) for r in results['hits']['hits']])
+        return intbitset([int(r['_id']) for r in results])
 
     def _search(self):
         from invenio_ext.es import es

--- a/invenio_search/version.py
+++ b/invenio_search/version.py
@@ -28,4 +28,4 @@ This file is imported by ``invenio_search.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.1.6.dev20160203"
+__version__ = "0.1.6.dev20160204"


### PR DESCRIPTION
- BETTER Makes recids property of Query API ES 2.0 compatible
  with usage of scan to get all recids instead of size 999999.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
